### PR TITLE
Fix packed matmul bug

### DIFF
--- a/src/kernels/backend_webgl.ts
+++ b/src/kernels/backend_webgl.ts
@@ -783,8 +783,12 @@ export class MathBackendWebGL implements KernelBackend {
 
     const dtype = upcastType(a.dtype, b.dtype);
 
-    const program = new MatMulPackedProgramCS(
-        a.shape, [batch, outerShapeA, outerShapeB], transposeA, transposeB);
+    const program = batch === 1 ?
+        new MatMulPackedProgramCS(
+            a.shape, [batch, outerShapeA, outerShapeB], transposeA,
+            transposeB) :
+        new MatMulPackedProgram(
+            a.shape, [batch, outerShapeA, outerShapeB], transposeA, transposeB);
     const output =
         this.makePackedTensor(program.outputShape, dtype) as Tensor3D;
     return this.compileAndRunCS<Tensor3D>(program, [a, b], output);

--- a/src/kernels/webgl/mulmat_packed_gpu_cs.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu_cs.ts
@@ -33,8 +33,10 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
     const sharedDim = transposeA ? aShape[1] : aShape[2];
     const sharedDimensionPacked = Math.ceil(sharedDim / 2);
 
-    const aSample = transposeA ? 'tileCol * 2, rc.y' : 'rc.y, tileCol * 2';
-    const bSample = transposeB ? 'rc.z, tileRow * 2' : 'tileRow * 2, rc.z';
+    const aSample = transposeA ? 'tileCol * 2, globalRow * 2' :
+                                 'globalRow * 2, tileCol * 2';
+    const bSample = transposeB ? 'globalCol * 2, tileRow * 2' :
+                                 'tileRow * 2, globalCol * 2';
     const aSwizzle = transposeA ? ['a.xxyy', 'a.zzww'] : ['a.xxzz', 'a.yyww'];
     const bSwizzle = transposeB ? ['b.xzxz', 'b.ywyw'] : ['b.xyxy', 'b.zwzw'];
 
@@ -63,6 +65,8 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
         ivec3 rc = getOutputCoords();
         int row = int(gl_LocalInvocationID.y);
         int col = int(gl_LocalInvocationID.x);
+        int globalRow = int(gl_GlobalInvocationID.y);
+        int globalCol = int(gl_GlobalInvocationID.x);
 
         // Loop over all tiles
         int numTiles = ${Math.ceil(sharedDimensionPacked / TS)};


### PR DESCRIPTION
1. Fix packed matmul bug.
2. Current MatMulPackedProgramCS doesn't support case that batchSize != 1, so we use MatMulPackedProgram in this case.

Hi @qjia7 , please take a look and help verify #6, thanks!