### PR TITLE
Enable WEBGL_PACK

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -309,7 +309,9 @@ export class Environment {
     } else if (feature === 'WEBGL_CPU_FORWARD') {
       return true;
     } else if (feature === 'WEBGL_PACK') {
-      return false;
+      // Make WEBGL_PACK default to true. You can turn off this feature by URL:
+      // http://localhost:1234/?tfjsflags=WEBGL_PACK:false
+      return this.get('WEBGL_VERSION') === 0 ? false : true;
     } else if (feature === 'WEBGL_PACK_BATCHNORMALIZATION') {
       return this.get('WEBGL_PACK');
     } else if (feature === 'WEBGL_PACK_CLIP') {

--- a/src/kernels/webgl/im2col_gpu_cs.ts
+++ b/src/kernels/webgl/im2col_gpu_cs.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Conv2DInfo} from '../../ops/conv_util';
+import {getGlslDifferences} from './glsl_version';
+import {GPGPUProgram} from './gpgpu_math';
+
+export class Im2ColProgramCS implements GPGPUProgram {
+  variableNames = ['A'];
+  outputShape: number[];
+  userCode: string;
+
+  constructor(
+      outputShape: number[], inputShape: number[], convInfo: Conv2DInfo) {
+    this.outputShape = outputShape;
+
+    const {
+      filterWidth,
+      inChannels,
+      strideWidth,
+      strideHeight,
+      padInfo,
+      outWidth,
+      dilationWidth,
+      dilationHeight
+    } = convInfo;
+    const {left, top} = padInfo;
+    const itemsPerBlockRow = inChannels * filterWidth;
+    const glsl = getGlslDifferences();
+
+    this.userCode = `
+      void main() {
+        ivec2 rc = getOutputCoords();
+
+        vec4 result = vec4(0);
+
+        for(int row=0; row<=1; row++) {
+          for(int col=0; col<=1; col++) {
+            int blockIndex = rc.y + col;
+            int pos = rc.x + row;
+
+            if(blockIndex >= ${outputShape[1]} || pos >= ${
+        outputShape[0]}) continue;
+
+            int offsetY = int(blockIndex / (${outWidth})) * ${strideHeight} - ${
+        top};
+            int d0 = offsetY + ${dilationHeight} * (pos / ${itemsPerBlockRow});
+
+            if(d0 >= ${inputShape[0]} || d0 < 0) continue;
+
+            int offsetX = int(mod(float(blockIndex), ${outWidth}.) * ${
+        strideWidth}. - ${left}.);
+            int d1 = offsetX + ${dilationWidth} * (int(mod(float(pos), ${
+        itemsPerBlockRow}.) / ${inChannels}.));
+
+            if(d1 >= ${inputShape[1]} || d1 < 0) continue;
+
+            result[row * 2 + col] = getA(d0, d1, int(mod(float(pos), ${
+        inChannels}.)));
+          }
+        }
+
+        imageStore(
+            ${glsl.output}, ivec2(gl_GlobalInvocationID.xy), result);
+      }
+    `;
+  }
+}


### PR DESCRIPTION
This commit switches all packed ops used in MobileNet to run on CS backend.

Now we keep WEBGL_PACK default to false. You can turn on this feature by URL:
http://localhost:1234/?tfjsflags=WEBGL_PACK:true

Besides, we add a seperate file for Im2ColProgramCS, which could be optimized in the future.