### PR TITLE
Add depthwiseConv2d with shared memory

### DIFF
--- a/src/kernels/webgl/conv_gpu_cs.ts
+++ b/src/kernels/webgl/conv_gpu_cs.ts
@@ -70,12 +70,11 @@ export class Conv2DProgramCS implements GPGPUProgram {
           int c = cd / CACHE_C;
           int d = cd - c * CACHE_C;
 
-          if ((cacheRCorner + r) >= 0 &&
-              (cacheCCorner + c) >= 0 &&
-              (cacheRCorner + r) < ${convInfo.inHeight} &&
-              (cacheCCorner + c) < ${convInfo.inWidth}) {
-            cache[r][cd] = getX(batch, cacheRCorner + r * ${dilationHeight},
-                                cacheCCorner + c, d);
+          int xR = cacheRCorner + r * ${dilationHeight};
+          int xC = cacheCCorner + c;
+          if (xR >= 0 && xR < ${convInfo.inHeight} &&
+              xC >= 0 && xC < ${convInfo.inWidth}) {
+            cache[r][cd] = getX(batch, xR, xC, d);
           }
 
           index += ${this.localGroupSize[0] * this.localGroupSize[1]};
@@ -99,11 +98,11 @@ export class Conv2DProgramCS implements GPGPUProgram {
         // ? = to be determined. : = across all values in that axis.
         float dotProd = 0.0;
         for (int wR = 0; wR < ${filterHeight}; wR++) {
-          int xR = xRCorner + wR;
+          int xR = xRCorner + wR * ${dilationHeight};
           if (xR < 0 || xR >= ${convInfo.inHeight}) {
             continue;
           }
-          int sR = xR - cacheRCorner;
+          int sR = wR;
 
           for (int wC = 0; wC < ${filterWidth}; wC++) {
             int xC = xCCorner + wC * ${dilationWidth};

--- a/src/kernels/webgl/conv_gpu_depthwise_cs.ts
+++ b/src/kernels/webgl/conv_gpu_depthwise_cs.ts
@@ -71,13 +71,13 @@ export class DepthwiseConv2DProgramCS implements GPGPUProgram {
           int c = cd / CACHE_C;
           int d = cd - c * CACHE_C;
 
-          if ((cacheRCorner + r) >= 0 &&
-              (cacheCCorner + c) >= 0 &&
-              (cacheRCorner + r) < ${convInfo.inHeight} &&
-              (cacheCCorner + c) < ${convInfo.inWidth} &&
-              (cacheDCorner + d) < ${convInfo.inChannels}) {
-            cache[r][cd] = getX(batch, cacheRCorner + r * ${dilationHeight},
-                                cacheCCorner + c, cacheDCorner + d);
+          int xR = cacheRCorner + r * ${dilationHeight};
+          int xC = cacheCCorner + c;
+          int xD = cacheDCorner + d;
+          if (xR >= 0 && xR < ${convInfo.inHeight} &&
+              xC >= 0 && xC < ${convInfo.inWidth} &&
+              xD < ${convInfo.inChannels}) {
+            cache[r][cd] = getX(batch, xR, xC, xD);
           }
 
           index += ${this.localGroupSize[0] * this.localGroupSize[1]};
@@ -104,11 +104,11 @@ export class DepthwiseConv2DProgramCS implements GPGPUProgram {
         float dotProd = 0.0;
         // TODO: Flatten the two for loops and vec4 the operations.
         for (int wR = 0; wR < ${filterHeight}; wR++) {
-          int xR = xRCorner + wR;
+          int xR = xRCorner + wR * ${dilationHeight};
           if (xR < 0 || xR >= ${xNumRows}) {
             continue;
           }
-          int sR = xR - cacheRCorner;
+          int sR = wR;
 
           for (int wC = 0; wC < ${filterWidth}; wC++) {
             int xC = xCCorner + wC * ${dilationWidth};

--- a/src/kernels/webgl/conv_gpu_depthwise_cs.ts
+++ b/src/kernels/webgl/conv_gpu_depthwise_cs.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Conv2DInfo} from '../../ops/conv_util';
+import {GPGPUProgram} from './gpgpu_math';
+
+export class DepthwiseConv2DProgramCS implements GPGPUProgram {
+  variableNames = ['x', 'W'];
+  outputShape: number[];
+  userCode: string;
+  localGroupSize: [number, number];
+
+  constructor(convInfo: Conv2DInfo) {
+    this.outputShape = convInfo.outShape;
+    const xNumRows = convInfo.inHeight;
+    const xNumCols = convInfo.inWidth;
+    const padTop = convInfo.padInfo.top;
+    const padLeft = convInfo.padInfo.left;
+    const strideHeight = convInfo.strideHeight;
+    const strideWidth = convInfo.strideWidth;
+    const dilationHeight = convInfo.dilationHeight;
+    const dilationWidth = convInfo.dilationWidth;
+    const filterHeight = convInfo.filterHeight;
+    const filterWidth = convInfo.filterWidth;
+    const channelMul = convInfo.outChannels / convInfo.inChannels;
+
+    this.localGroupSize = [8 * channelMul, 7];
+    // outWidth should be divisible by localGroupSize[1]
+
+    this.userCode = `
+      const ivec2 strides = ivec2(${strideHeight}, ${strideWidth});
+      const ivec2 pads = ivec2(${padTop}, ${padLeft});
+
+      const int CACHE_H = ${filterHeight};
+      const int CACHE_W = ${
+        (this.localGroupSize[1] - 1) * strideWidth + filterWidth +
+        (filterWidth - 1) * (dilationWidth - 1)};
+      const int CACHE_C = ${this.localGroupSize[0] / channelMul};
+      const int CACHE_WC = CACHE_W * CACHE_C;
+      const int CACHE_HWC = CACHE_H * CACHE_W * CACHE_C;
+      // Combine CACHE_W and CACHE_C
+      shared float cache[CACHE_H][CACHE_W * CACHE_C];
+
+      void main() {
+        ivec4 coords = getFirstThreadOutputCoords();
+        int batch = coords.x;
+        ivec2 cacheRCCorner = coords.yz * strides - pads;
+        int cacheRCorner = cacheRCCorner.x;
+        int cacheCCorner = cacheRCCorner.y;
+        int cacheDCorner = coords.w / ${channelMul};
+
+        // Fill cache using all threads in a local group
+        int index = int(gl_LocalInvocationIndex);
+        while (index < CACHE_HWC) {
+          int r = index / CACHE_WC;
+          int cd = index - r * CACHE_WC;
+          int c = cd / CACHE_C;
+          int d = cd - c * CACHE_C;
+
+          if ((cacheRCorner + r) >= 0 &&
+              (cacheCCorner + c) >= 0 &&
+              (cacheRCorner + r) < ${convInfo.inHeight} &&
+              (cacheCCorner + c) < ${convInfo.inWidth} &&
+              (cacheDCorner + d) < ${convInfo.inChannels}) {
+            cache[r][cd] = getX(batch, cacheRCorner + r * ${dilationHeight},
+                                cacheCCorner + c, cacheDCorner + d);
+          }
+
+          index += ${this.localGroupSize[0] * this.localGroupSize[1]};
+        }
+
+        memoryBarrierShared();
+        barrier();
+
+        // Discard threads that are out of X bounds
+        if (int(gl_GlobalInvocationID.x) >= ${convInfo.outChannels}) {
+          return;
+        }
+
+        coords = getOutputCoords();
+        ivec2 xRCCorner = coords.yz * strides - pads;
+        int xRCorner = xRCCorner.x;
+        int xCCorner = xRCCorner.y;
+        int d2 = coords.w;
+        int d1 = d2 / ${channelMul};
+        int q = d2 - d1 * ${channelMul};
+
+        // Convolve x(?, ?, d1) with w(:, :, d1, q) to get y(yR, yC, d2).
+        // ? = to be determined. : = across all values in that axis.
+        float dotProd = 0.0;
+        // TODO: Flatten the two for loops and vec4 the operations.
+        for (int wR = 0; wR < ${filterHeight}; wR++) {
+          int xR = xRCorner + wR;
+          if (xR < 0 || xR >= ${xNumRows}) {
+            continue;
+          }
+          int sR = xR - cacheRCorner;
+
+          for (int wC = 0; wC < ${filterWidth}; wC++) {
+            int xC = xCCorner + wC * ${dilationWidth};
+            if (xC < 0 || xC >= ${xNumCols}) {
+              continue;
+            }
+            int sC = (xC - cacheCCorner) * CACHE_C;
+
+            float xVal = cache[sR][sC + d1 - cacheDCorner];
+            float wVal = getW(wR, wC, d1, q);
+            dotProd += xVal * wVal;
+          }
+        }
+        setOutput(dotProd);
+      }
+    `;
+  }
+}

--- a/src/kernels/webgl/conv_gpu_depthwise_cs.ts
+++ b/src/kernels/webgl/conv_gpu_depthwise_cs.ts
@@ -49,7 +49,10 @@ export class DepthwiseConv2DProgramCS implements GPGPUProgram {
       const int CACHE_W = ${
         (this.localGroupSize[1] - 1) * strideWidth + filterWidth +
         (filterWidth - 1) * (dilationWidth - 1)};
-      const int CACHE_C = ${this.localGroupSize[0] / channelMul};
+      const int CACHE_C = ${
+        this.localGroupSize[0] < convInfo.outChannels ?
+            this.localGroupSize[0] / channelMul :
+            convInfo.inChannels};
       const int CACHE_WC = CACHE_W * CACHE_C;
       const int CACHE_HWC = CACHE_H * CACHE_W * CACHE_C;
       // Combine CACHE_W and CACHE_C


### PR DESCRIPTION
This is a no-pack version of depthwiseConv2d. You can test it on
mobilenet by visiting http://localhost:1234/?tfjsflags=WEBGL_PACK:false,
and it works well now.

Some limitations:
1. Output texture shape must be [NHW, C]
2. OutWidth should be divisible by localGroupSize[1]