### PR TITLE
[Mulmat] register flags for matmul

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -308,6 +308,16 @@ export class Environment {
       return isChrome();
     } else if (feature === 'WEBGL_CPU_FORWARD') {
       return true;
+    } else if (feature === 'WEBGL_MATMUL_VERSION') {
+      // 0: MatMulPackedProgram
+      // 1: MatMulPackedProgramCS
+      // 2: MatMulPackedProgramCSV2
+      // 3: MatMulPackedProgramCSV3
+      return 1;
+    } else if (feature === 'WEBGL_MATMUL_TS') {
+      return 16;
+    } else if (feature === 'WEBGL_MATMUL_WPT') {
+      return 4;
     } else if (feature === 'WEBGL_PACK') {
       // Make WEBGL_PACK default to true. You can turn off this feature by URL:
       // http://localhost:1234/?tfjsflags=WEBGL_PACK:false

--- a/src/environment_util.ts
+++ b/src/environment_util.ts
@@ -28,6 +28,13 @@ export interface Features {
   'WEBGL_LAZILY_UNPACK'?: boolean;
   // Whether the WebGL backend will sometimes forward ops to the CPU.
   'WEBGL_CPU_FORWARD'?: boolean;
+  // 0: MatMulPackedProgram, 1: MatMulPackedProgramCS,
+  // 2: MatMulPackedProgramCSV2, 3:MatMulPackedProgramCSV3
+  'WEBGL_MATMUL_VERSION'?: number;
+  // Tile size in MatMulPackedProgramCS*
+  'WEBGL_MATMUL_TS'?: number;
+  // Work per thread in MatMulPackedProgramCSV*
+  'WEBGL_MATMUL_WPT'?: number;
   // Whether to turn all packing related flags on.
   'WEBGL_PACK'?: boolean;
   // Whether we will pack the batchnormalization op.
@@ -111,6 +118,9 @@ export const URL_PROPERTIES: URLProperty[] = [
   {name: 'IS_BROWSER', type: Type.BOOLEAN},
   {name: 'WEBGL_LAZILY_UNPACK', type: Type.BOOLEAN},
   {name: 'WEBGL_CPU_FORWARD', type: Type.BOOLEAN},
+  {name: 'WEBGL_MATMUL_VERSION', type: Type.NUMBER},
+  {name: 'WEBGL_MATMUL_TS', type: Type.NUMBER},
+  {name: 'WEBGL_MATMUL_WPT', type: Type.NUMBER},
   {name: 'WEBGL_PACK', type: Type.BOOLEAN},
   {name: 'WEBGL_PACK_BATCHNORMALIZATION', type: Type.BOOLEAN},
   {name: 'WEBGL_PACK_CLIP', type: Type.BOOLEAN},

--- a/src/kernels/webgl/mulmat_packed_gpu_cs.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu_cs.ts
@@ -26,7 +26,7 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
 
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
-      transposeA = false, transposeB = false, addBias = false,
+      transposeA = false, transposeB = false, TS: number, addBias = false,
       activation: string = null) {
     this.outputShape = outputShape;
 
@@ -53,8 +53,7 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
     if (addBias) {
       this.variableNames.push('bias');
     }
-    this.localGroupSize = [32, 32];
-    const TS = 32;
+    this.localGroupSize = [TS, TS];
     this.userCode = `
       ${activationSnippet}
 

--- a/src/kernels/webgl/mulmat_packed_gpu_cs_v2.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu_cs_v2.ts
@@ -17,7 +17,7 @@
 
 import {GPGPUProgram} from './gpgpu_math';
 
-export class MatMulPackedProgramCS implements GPGPUProgram {
+export class MatMulPackedProgramCSV2 implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
   usesPackedTextures = true;
   outputShape: number[];
@@ -27,14 +27,12 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
 
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
-      transposeA = false, transposeB = false, addBias = false,
-      activation: string = null) {
+      transposeA = false, transposeB = false, TS: number, WPT: number,
+      addBias = false, activation: string = null) {
     this.outputShape = outputShape;
 
     const sharedDim = transposeA ? aShape[1] : aShape[2];
     const sharedDimensionPacked = Math.ceil(sharedDim / 2);
-    const TS = 16;
-    const WPT = 2;
     const RTS = TS / WPT;
     this.localGroupSize = [TS, RTS];
     this.workPerThread = [1, WPT];

--- a/src/kernels/webgl/mulmat_packed_gpu_cs_v3.ts
+++ b/src/kernels/webgl/mulmat_packed_gpu_cs_v3.ts
@@ -17,7 +17,7 @@
 
 import {GPGPUProgram} from './gpgpu_math';
 
-export class MatMulPackedProgramCS implements GPGPUProgram {
+export class MatMulPackedProgramCSV3 implements GPGPUProgram {
   variableNames = ['matrixA', 'matrixB'];
   usesPackedTextures = true;
   outputShape: number[];
@@ -27,14 +27,12 @@ export class MatMulPackedProgramCS implements GPGPUProgram {
 
   constructor(
       aShape: [number, number, number], outputShape: [number, number, number],
-      transposeA = false, transposeB = false, addBias = false,
-      activation: string = null) {
+      transposeA = false, transposeB = false, TS: number, WPT: number,
+      addBias = false, activation: string = null) {
     this.outputShape = outputShape;
 
     const sharedDim = transposeA ? aShape[1] : aShape[2];
     const sharedDimensionPacked = Math.ceil(sharedDim / 2);
-    const TS = 16;
-    const WPT = 4;
     const RTS = TS / WPT;
     this.localGroupSize = [RTS, RTS];
     this.workPerThread = [WPT, WPT];


### PR DESCRIPTION
Register 3 flags for matmul.

WEBGL_MATMUL_VERSION:
  0: MatMulPackedProgram,     1: MatMulPackedProgramCS,
  2: MatMulPackedProgramCSV2, 3: MatMulPackedProgramCSV3

WEBGL_MATMUL_TS:
  Set tileSize in MatMulPackedProgramCS*

WEBGL_MATMUL_WPT:
  Set workPerThread in MatMulPackedProgramCSV*

You can set these flags through URL:
http://localhost:1234/?tfjsflags=WEBGL_MATMUL_VERSION:0
http://localhost:1234/?tfjsflags=WEBGL_MATMUL_VERSION:1,WEBGL_MATMUL_TS:16
http://localhost:1234/?tfjsflags=WEBGL_MATMUL_VERSION:2,WEBGL_MATMUL_TS:32,WEBGL_MATMUL_WPT:4
http://localhost:1234/?tfjsflags=WEBGL_MATMUL_VERSION:3,WEBGL_MATMUL_TS:32,WEBGL_MATMUL_WPT:4